### PR TITLE
Fixed deadlock issue when providing invalid login info

### DIFF
--- a/src/ofxXMPP.cpp
+++ b/src/ofxXMPP.cpp
@@ -85,7 +85,9 @@ void ofxXMPP::conn_handler(xmpp_conn_t * const conn, const xmpp_conn_event_t sta
         	xmpp->mutex.unlock();
         }else{
         	xmpp->mutex.unlock();
-        	xmpp->stop();
+			if (((ofxXMPP*) userdata)->getConnectionState() == ofxXMPPConnected){ // without this check xmpp->stop will be caught in a deadlock
+				xmpp->stop();
+			}
         }
         xmpp->connectionState = ofxXMPPDisconnected;
     }


### PR DESCRIPTION
Hi arturoc,

This is Kevin from the JaJan/telekinect project. I've discovered an issue with incorrect login information when trying to login to an xmpp server. There's a deadlock in conn_handler, causing the xmpp state to be trapped in ofxXMPPConnecting state. This deadlock is caused by calling xmpp->stop() when the client is not connected yet, i.e. when user is still logging in. A simple check of the current state in conn_handler prevents this problem.
